### PR TITLE
PyTorch Habana Gaudi enablement patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,9 @@ cmake_dependent_option(
     USE_GLOO "Use Gloo. Only available if USE_DISTRIBUTED is on." ON
     "USE_DISTRIBUTED" OFF)
 cmake_dependent_option(
+    USE_HCL "Use HCL. Only available if USE_DISTRIBUTED is on." ON
+    "USE_DISTRIBUTED" OFF)
+cmake_dependent_option(
     USE_TENSORPIPE "Use TensorPipe. Only available if USE_DISTRIBUTED is on." ON
     "USE_DISTRIBUTED" OFF)
 option(USE_TBB "Use TBB" OFF)

--- a/aten/src/ATen/core/DeprecatedTypeProperties.h
+++ b/aten/src/ATen/core/DeprecatedTypeProperties.h
@@ -42,6 +42,10 @@ class CAFFE2_API DeprecatedTypeProperties {
     return backendToDeviceType(backend_) == kCUDA;
   }
 
+  bool is_habana() const {
+    return backendToDeviceType(backend_) == kHABANA;
+  }
+
   ScalarType scalarType() const {
     return scalar_type_;
   }

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -33,6 +33,7 @@ namespace c10 {
   _(prim, Eval)                      \
   _(prim, Expand) /* onnx */         \
   _(prim, FusionGroup)               \
+  _(prim, HabanaFusedOp)             \
   _(prim, CudaFusionGroup)           \
   _(prim, FunctionalGraph)           \
   _(prim, DifferentiableGraph)       \

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -636,6 +636,11 @@ struct CAFFE2_API TensorType : public Type {
   c10::optional<at::Device> device() const {
     return device_;
   }
+  void set_device(c10::optional<at::Device> device) {
+    if (device) {
+      device_ = device;
+    }
+  }
   c10::optional<at::ScalarType> scalarType() const {
     return scalar_type_;
   }

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -976,6 +976,7 @@ const SymbolicShape& TensorType::symbolic_sizes() const {
 
 bool TensorType::isSubtypeOfExt(const TypePtr rhs, std::ostream* why_not) const {
   if (auto rhs_p = rhs->cast<TensorType>()) {
+    rhs_p->set_device(device());
     // if we have the same pointer, avoid computing the merge
     if (this == rhs_p.get()) {
       return true;

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -77,6 +77,9 @@ struct CAFFE2_API DispatchStub<rT (*)(Args...), T> {
     } else if (device_type == DeviceType::CUDA) {
       AT_ASSERTM(cuda_dispatch_ptr, "DispatchStub: missing CUDA kernel");
       return (*cuda_dispatch_ptr)(std::forward<ArgTypes>(args)...);
+    } else if (device_type == DeviceType::HABANA) {
+      AT_ASSERTM(habana_dispatch_ptr, "DispatchStub: missing HABANA kernel");
+      return (*habana_dispatch_ptr)(std::forward<ArgTypes>(args)...);
     } else if (device_type == DeviceType::HIP) {
       AT_ASSERTM(hip_dispatch_ptr, "DispatchStub: missing HIP kernel");
       return (*hip_dispatch_ptr)(std::forward<ArgTypes>(args)...);
@@ -110,10 +113,12 @@ struct CAFFE2_API DispatchStub<rT (*)(Args...), T> {
   std::atomic<FnPtr> cpu_dispatch_ptr;
   FnPtr cuda_dispatch_ptr;
   FnPtr hip_dispatch_ptr;
+  FnPtr habana_dispatch_ptr;
 #else
   std::atomic<FnPtr> cpu_dispatch_ptr{nullptr};
   FnPtr cuda_dispatch_ptr = nullptr;
   FnPtr hip_dispatch_ptr = nullptr;
+  FnPtr habana_dispatch_ptr = nullptr;
 #endif
   static FnPtr DEFAULT;
 #ifdef HAVE_AVX_CPU_DEFINITION
@@ -137,6 +142,14 @@ struct RegisterHIPDispatch {
   RegisterHIPDispatch(DispatchStub<FnPtr, T>& stub, FnPtr value) {
     // TODO: make this point at hip_dispatch_ptr
     stub.cuda_dispatch_ptr = value;
+  }
+};
+
+template <typename FnPtr, typename T>
+struct RegisterHABANADispatch {
+  RegisterHABANADispatch(DispatchStub<FnPtr, T>& stub, FnPtr value) {
+    // TODO: make this point at habana_dispatch_ptr
+    stub.habana_dispatch_ptr = value;
   }
 };
 } // anonymous namespace

--- a/aten/src/ATen/native/TypeProperties.cpp
+++ b/aten/src/ATen/native/TypeProperties.cpp
@@ -10,6 +10,10 @@ bool is_cuda(const Tensor& self) {
   return self.is_cuda();
 }
 
+bool is_habana(const Tensor& self) {
+  return self.is_habana();
+}
+
 bool is_distributed(const Tensor& self) {
   return false;
 }

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -308,6 +308,9 @@ class CAFFE2_API Tensor {
   /// Returns if a `Tensor` has CUDA backend.
   bool is_cuda() const;
 
+  /// Returns if a `Tensor` has HABANA backend.
+  bool is_habana() const;
+
   /// Returns if a `Tensor` has HIP backend.
   bool is_hip() const;
 

--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -88,6 +88,11 @@ bool Tensor::is_cuda() const {
   return impl_->is_cuda();
 }
 
+bool Tensor::is_habana() const {
+  // NB: this is not a native function to avoid dispatching overhead.
+  return impl_->is_habana();
+}
+
 NamedTensorMeta* Tensor::get_named_tensor_meta() {
   return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
 }
@@ -107,6 +112,10 @@ bool Tensor::has_names() const {
 
 bool is_cuda(Tensor self) {
   return self.is_cuda();
+}
+
+bool is_habana(Tensor self) {
+  return self.is_habana();
 }
 
 bool Tensor::is_hip() const {

--- a/c10/core/Backend.h
+++ b/c10/core/Backend.h
@@ -29,6 +29,7 @@ enum class Backend {
   CPU,
   CUDA,
   HIP,
+  HABANA,
   FPGA,
   SparseCPU,
   SparseCUDA,
@@ -70,6 +71,8 @@ static inline Backend toDense(Backend b) {
       return Backend::CUDA;
     case Backend::HIP:
       return Backend::HIP;
+    case Backend::HABANA:
+      return Backend::HABANA;
     case Backend::FPGA:
       return Backend::FPGA;
     case Backend::MSNPU:
@@ -98,6 +101,8 @@ static inline Backend dispatchKeyToBackend(DispatchKey t) {
     return Backend::CUDA;
   } else if (t == DispatchKey::HIP) {
     return Backend::HIP;
+  } else if (t == DispatchKey::HABANATensorId) {
+    return Backend::HABANA;
   } else if (t == DispatchKey::FPGA) {
     return Backend::FPGA;
   } else if (t == DispatchKey::MSNPU) {
@@ -133,6 +138,8 @@ static inline DispatchKey backendToDispatchKey(Backend b) {
       return DispatchKey::CUDA;
     case Backend::HIP:
       return DispatchKey::HIP;
+    case Backend::HABANA:
+      return DispatchKey::HABANATensorId;
     case Backend::FPGA:
       return DispatchKey::FPGA;
     case Backend::MSNPU:
@@ -168,6 +175,8 @@ static inline DeviceType backendToDeviceType(Backend b) {
       return DeviceType::CUDA;
     case Backend::HIP:
       return DeviceType::HIP;
+    case Backend::HABANA:
+      return DeviceType::HABANA;
     case Backend::FPGA:
       return DeviceType::FPGA;
     case Backend::MSNPU:
@@ -201,6 +210,8 @@ static inline Backend backendToCPU(Backend b) {
     case Backend::CUDA:
       return Backend::CPU;
     case Backend::HIP:
+      return Backend::CPU;
+    case Backend::HABANA:
       return Backend::CPU;
     case Backend::FPGA:
       return Backend::CPU;
@@ -275,6 +286,8 @@ static inline const char* toString(Backend b) {
       return "CUDA";
     case Backend::HIP:
       return "HIP";
+    case Backend::HABANA:
+      return "HABANA";
     case Backend::FPGA:
       return "FPGA";
     case Backend::MSNPU:

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -30,7 +30,7 @@
 namespace c10 {
 namespace {
 DeviceType parse_type(const std::string& device_string) {
-  static const std::array<std::pair<std::string, DeviceType>, 10> types = {{
+  static const std::array<std::pair<std::string, DeviceType>, 11> types = {{
       {"cpu", DeviceType::CPU},
       {"cuda", DeviceType::CUDA},
       {"mkldnn", DeviceType::MKLDNN},
@@ -41,6 +41,7 @@ DeviceType parse_type(const std::string& device_string) {
       {"fpga", DeviceType::FPGA},
       {"msnpu", DeviceType::MSNPU},
       {"xla", DeviceType::XLA},
+      {"habana", DeviceType::HABANA},
   }};
   auto device = std::find_if(
       types.begin(),
@@ -52,7 +53,7 @@ DeviceType parse_type(const std::string& device_string) {
     return device->second;
   }
   AT_ERROR(
-      "Expected one of cpu, cuda, mkldnn, opengl, opencl, ideep, hip, msnpu, xla device type at start of device string: ", device_string);
+      "Expected one of cpu, cuda, mkldnn, opengl, opencl, ideep, hip, msnpu, xla, habana device type at start of device string: ", device_string);
 }
 } // namespace
 

--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -81,6 +81,10 @@ struct C10_API Device final {
     return type_ == DeviceType::CUDA;
   }
 
+  bool is_habana() const noexcept{
+   return type_ == DeviceType::HABANA;
+  }
+
   /// Return true if the device is of CPU type.
   bool is_cpu() const noexcept {
     return type_ == DeviceType::CPU;

--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -29,6 +29,8 @@ std::string DeviceTypeName(DeviceType d, bool lower_case) {
       return lower_case ? "xla" : "XLA";
     case DeviceType::Vulkan:
       return lower_case ? "vulkan" : "VULKAN";
+    case DeviceType::HABANA:
+      return lower_case ? "habana" : "HABANA";
     default:
       AT_ERROR(
           "Unknown device: ",
@@ -62,6 +64,7 @@ bool isValidDeviceType(DeviceType d) {
     case DeviceType::MSNPU:
     case DeviceType::XLA:
     case DeviceType::Vulkan:
+    case DeviceType::HABANA:
       return true;
     default:
       return false;

--- a/c10/core/DeviceType.h
+++ b/c10/core/DeviceType.h
@@ -24,11 +24,12 @@ enum class DeviceType : int16_t {
   MSNPU = 8, // MSNPU
   XLA = 9, // XLA / TPU
   Vulkan = 10, // Vulkan
+  HABANA = 11, // HABAPA / HPU
   // NB: If you add more devices:
   //  - Change the implementations of DeviceTypeName and isValidDeviceType
   //    in DeviceType.cpp
   //  - Change the number below
-  COMPILE_TIME_MAX_DEVICE_TYPES = 11,
+  COMPILE_TIME_MAX_DEVICE_TYPES = 12,
   ONLY_FOR_TEST = 20901, // This device type is only for test.
 };
 
@@ -39,6 +40,7 @@ constexpr DeviceType kFPGA = DeviceType::FPGA;
 constexpr DeviceType kMSNPU = DeviceType::MSNPU;
 constexpr DeviceType kXLA = DeviceType::XLA;
 constexpr DeviceType kVulkan = DeviceType::Vulkan;
+constexpr DeviceType kHABANA = DeviceType::HABANA;
 
 // define explicit int constant
 constexpr int COMPILE_TIME_MAX_DEVICE_TYPES =

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -57,6 +57,7 @@ enum class DispatchKey : uint8_t {
          // test/cpp_extensions/msnpu_extension.cpp
   XLA, // lives out of tree at https://github.com/pytorch/xla
   Vulkan,
+  HABANATensorId,
 
   // These are Caffe2 device types which we grandfathered into
   // DispatchKey.

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -455,6 +455,11 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         key_set_.has(DispatchKey::QuantizedCUDA);
   }
 
+  bool is_habana() const {
+    // NB: This method is not virtual and avoid dispatches for performance reasons.
+    return key_set_.has(DispatchKey::HABANATensorId);
+  }
+
   bool is_hip() const {
     // NB: This method is not virtual and avoid dispatches for performance reasons.
     return key_set_.has(DispatchKey::HIP) ||

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -405,6 +405,8 @@ struct C10_API TensorOptions {
             return DispatchKey::XLA;
           case DeviceType::Vulkan:
             return DispatchKey::Vulkan;
+          case DeviceType::HABANA:
+            return DispatchKey::HABANATensorId;
           default:
             AT_ERROR("Unsupported device type for dense layout: ", device().type());
         }
@@ -645,6 +647,8 @@ inline DeviceType computeDeviceType(DispatchKey tid) {
     return DeviceType::XLA;
   } else if (tid == DispatchKey::XLAPreAutograd) {
     return DeviceType::XLA;
+  } else if (tid == DispatchKey::HABANATensorId) {
+    return DeviceType::HABANA;
   } else if (tid == DispatchKey::SparseCPU) {
     return DeviceType::CPU;
   } else if (tid == DispatchKey::SparseCUDA) {

--- a/caffe2/proto/caffe2.proto
+++ b/caffe2/proto/caffe2.proto
@@ -228,8 +228,9 @@ enum DeviceTypeProto {
   PROTO_FPGA = 7;                   // FPGA
   PROTO_MSNPU = 8;                  // MSNPU
   PROTO_XLA = 9;                    // XLA / TPU
+  PROTO_HABANA = 10;                // HABANA / HPU
   // Change the following number if you add more devices in the code.
-  PROTO_COMPILE_TIME_MAX_DEVICE_TYPES = 10;
+  PROTO_COMPILE_TIME_MAX_DEVICE_TYPES = 11;
   PROTO_ONLY_FOR_TEST = 20901;   // This device type is only for test.
 }
 

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -17,6 +17,13 @@ if(USE_TBB)
 include_directories(${TBB_ROOT_DIR}/include)
 endif()
 
+if (USE_HCL)
+  include_directories($ENV{SYNAPSE_ROOT}/include)
+  include_directories($ENV{ABSEIL_CPP_INCLUDE_DIR})
+  include_directories($ENV{PYTORCH_MODULES_ROOT_PATH}/distributed)
+  include_directories($ENV{PYTORCH_MODULES_ROOT_PATH}/pytorch_helpers)
+endif()
+
 set(TORCH_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(TORCH_ROOT "${TORCH_SRC_DIR}/..")
 

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -16,6 +16,10 @@
 #include <c10d/ProcessGroupMPI.hpp>
 #endif
 
+#ifdef USE_C10D_HCL
+#include <c10d/ProcessGroupHCL.hpp>
+#endif
+
 #include <c10d/PrefixStore.hpp>
 #include <c10d/ProcessGroupRoundRobin.hpp>
 #include <c10d/TCPStore.hpp>
@@ -683,6 +687,21 @@ They are used in specifying strategies for reduction collectives, e.g.,
   processGroupMPI.def_static("create", [](std::vector<int> ranks) {
     return ::c10d::ProcessGroupMPI::createProcessGroupMPI(ranks);
   });
+#endif
+
+#ifdef USE_C10D_HCL
+  shared_ptr_class_<::c10d::ProcessGroupHCL>(
+      module, "ProcessGroupHCL", processGroup)
+      .def(
+          py::init<
+              const std::shared_ptr<::c10d::Store>&,
+              int,
+              int,
+              const std::chrono::milliseconds&>(),
+          py::arg("store"),
+          py::arg("rank"),
+          py::arg("size"),
+          py::arg("timeout") = std::chrono::milliseconds(10 * 1000));
 #endif
 
   shared_ptr_class_<::c10d::ProcessGroup::Work>(module, "Work")

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -142,7 +142,7 @@ Reducer::Reducer(
 
       for (size_t i = 0; i < replica_count; i++) {
         at::TensorOptions options;
-        options = options.dtype(at::kInt);
+        options = options.dtype(at::kFloat);
 
         if (replicas_[i][0].is_cuda()) {
           at::DeviceGuard g(replicas_[i][0].device());

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -473,6 +473,7 @@ void AliasDb::analyzeImpl(Node* node) {
     case prim::Loop:
       return analyzeLoop(node);
     case prim::FusionGroup:
+    case prim::HabanaFusedOp:
     case prim::CudaFusionGroup:
     case prim::FunctionalGraph:
     case prim::DifferentiableGraph:

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -432,6 +432,7 @@ void Node::lint() const {
       // longer.
       break;
     case prim::FusionGroup:
+    case prim::HabanaFusedOp:
     case prim::CudaFusionGroup:
       checkSameDevice(this);
       // TODO: Typecheck the parameters

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -192,6 +192,8 @@ struct GraphFuser {
       return canFuseOnCPU();
     } else if ((*device).is_cuda()) {
       return canFuseOnGPU();
+    } else if ((*device).is_habana()) {
+      return false;
     }
     throw std::runtime_error("Unknown device");
   }

--- a/torch/csrc/jit/passes/inline_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/inline_autodiff_subgraphs.cpp
@@ -13,7 +13,7 @@ namespace jit {
 bool canRunWithAutograd(Node* node) {
   auto kind = node->kind();
   return kind != prim::FusionGroup && kind != prim::CudaFusionGroup &&
-      (kind.is_aten() || kind.is_prim());
+      kind != prim::HabanaFusedOp && (kind.is_aten() || kind.is_prim());
 }
 
 namespace {

--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -209,6 +209,7 @@ bool printerHasSpecialCaseFor(Symbol sym) {
       prim::Drop, // used in interpreter only
       prim::FusedConcat, // optimization pass adds it
       prim::FusionGroup, // optimization pass adds it
+      prim::HabanaFusedOp, // optimization pass adds it
       prim::CudaFusionGroup, // optimization pass adds it
       prim::Load, // used in interpreter only
       prim::MMTreeReduce, // used as an optimization
@@ -240,6 +241,7 @@ bool aliasAnalysisHasSpecialCaseFor(Symbol symbol) {
       prim::If,
       prim::Loop,
       prim::FusionGroup,
+      prim::HabanaFusedOp,
       prim::CudaFusionGroup,
       prim::DifferentiableGraph,
       prim::FunctionalGraph,

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -34,6 +34,7 @@ struct PyTensorType {
   THPDtype* dtype;
   THPLayout* layout;
   bool is_cuda;
+  bool is_habana;
   char name[64];
   int backend;
   int scalar_type;
@@ -114,6 +115,14 @@ PyObject *Tensor_is_cuda(PyTensorType* self, void *unused) {
   }
 }
 
+PyObject *Tensor_is_habana(PyTensorType* self, void *unused) {
+  if (self->is_habana) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+}
+
 PyObject *Tensor_is_sparse(PyTensorType *self, void *unused) {
   if (self->layout->layout == at::Layout::Strided) {
     Py_RETURN_FALSE;
@@ -133,6 +142,7 @@ static struct PyGetSetDef metaclass_properties[] = {
   {"dtype",        (getter)Tensor_dtype, nullptr, nullptr, nullptr},
   {"layout",       (getter)Tensor_layout, nullptr, nullptr, nullptr},
   {"is_cuda",      (getter)Tensor_is_cuda, nullptr, nullptr, nullptr},
+  {"is_habana",      (getter)Tensor_is_habana, nullptr, nullptr, nullptr},
   {"is_sparse",    (getter)Tensor_is_sparse, nullptr, nullptr, nullptr},
   {nullptr}
 };
@@ -214,6 +224,7 @@ static void set_type(PyTensorType& type_obj, Backend backend, ScalarType scalarT
   type_obj.layout = torch::getTHPLayout(layout_from_backend(backend));
   type_obj.dtype = torch::getTHPDtype(scalarType);
   type_obj.is_cuda = (backend == at::Backend::CUDA || backend == at::Backend::SparseCUDA);
+  type_obj.is_habana = (backend == at::Backend::HABANA);
 }
 
 static void set_name(PyTensorType& type_obj, const std::string& name) {

--- a/torch/lib/c10d/CMakeLists.txt
+++ b/torch/lib/c10d/CMakeLists.txt
@@ -27,6 +27,11 @@ if(USE_NCCL)
   option(USE_C10D_NCCL "USE C10D NCCL" ON)
 endif()
 
+if(USE_HCL)
+  option(USE_C10D_HCL "USE C10D HCL" ON)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
+
 if(USE_MPI)
   find_package(MPI)
   if(MPI_FOUND)
@@ -59,6 +64,10 @@ set(C10D_LIBS torch)
 if(USE_C10D_NCCL)
   list(APPEND C10D_SRCS ProcessGroupNCCL.cpp NCCLUtils.cpp)
   list(APPEND C10D_LIBS __caffe2_nccl)
+endif()
+
+if(USE_C10D_HCL)
+  list(APPEND C10D_SRCS ProcessGroupHCL.cpp )
 endif()
 
 if(USE_C10D_MPI)
@@ -109,6 +118,10 @@ if(USE_C10D_NCCL)
   target_compile_definitions(c10d INTERFACE USE_C10D_NCCL)
 endif()
 
+if(USE_C10D_HCL)
+  target_compile_definitions(c10d INTERFACE USE_C10D_HCL)
+endif()
+
 if(USE_C10D_MPI)
   target_compile_definitions(c10d INTERFACE USE_C10D_MPI)
 endif()
@@ -133,6 +146,18 @@ endif()
 if(USE_C10D_NCCL)
   copy_header(ProcessGroupNCCL.hpp)
   copy_header(NCCLUtils.hpp)
+endif()
+
+if(USE_C10D_HCL)
+  add_library(Distributed SHARED IMPORTED)
+  set_target_properties(Distributed PROPERTIES
+  IMPORTED_LOCATION "$ENV{BUILD_ROOT_LATEST}/libhabana_pytorch_distributed_plugin.so"
+  INTERFACE_INCLUDE_DIRECTORIES "$ENV{SYNAPSE_ROOT}/include;$ENV{PYTORCH_MODULES_ROOT_PATH}/pytorch_helpers;$ENV{ABSEIL_CPP_INCLUDE_DIR};$ENV{PYTORCH_MODULES_ROOT_PATH}/distributed"
+  )
+
+  target_link_libraries(c10d PRIVATE "${C10D_LIBS}" Distributed)
+  target_include_directories(c10d PRIVATE ${CMAKE_SOURCE_DIR})
+  copy_header(ProcessGroupHCL.hpp)
 endif()
 
 if(USE_C10D_MPI)

--- a/torch/lib/c10d/ProcessGroupHCL.cpp
+++ b/torch/lib/c10d/ProcessGroupHCL.cpp
@@ -1,0 +1,349 @@
+#include <c10d/ProcessGroupHCL.hpp>
+#include <map>
+
+using namespace synapse_helpers;
+
+namespace c10d {
+
+namespace {
+
+std::map<at::ScalarType, synDataType> hclDataType = {
+   {at::kByte, syn_type_int8},
+   {at::kChar, syn_type_int8},
+   {at::kDouble, syn_type_na},
+   {at::kFloat, syn_type_float},
+   {at::kHalf, syn_type_bf16},
+   {at::kInt, syn_type_int32},
+   {at::kLong, syn_type_na},
+   {at::kShort, syn_type_int16},
+};
+
+// HCL op mapping
+std::map<ReduceOp, HCL_Op> hclOp = {
+    {ReduceOp::MIN, eHCLOpNone},
+    {ReduceOp::MAX, eHCLOpNone},
+    {ReduceOp::SUM, eHCLSum},
+    {ReduceOp::PRODUCT, eHCLMul},
+};
+
+HCL_Op getHCLOpType(ReduceOp type) {
+  try {
+    return hclOp.at(type);
+  } catch (std::out_of_range& e) {
+    throw std::runtime_error("Unsupported operation type for HCL process group");
+  }
+}
+
+synDataType getHCLDataType(at::ScalarType type) {
+  try {
+    return hclDataType.at(type);
+  } catch (std::out_of_range& e) {
+    throw std::runtime_error("Unsupported data type for HCL process group");
+  }
+}
+
+}
+
+hcl_communicator& ProcessGroupHCL::getComm(int deviceId) {
+  if (hcl_communicator_.find(deviceId) == hcl_communicator_.end())
+  {
+    char* config_json_path = std::getenv("HCL_CONFIG_PATH");
+    if (!config_json_path) {
+      LOG(FATAL) << "Please export HCL_CONFIG_PATH...";
+    }
+    HCL_Comm pgComm_ = HCL_COMM_WORLD;
+    hcl_communicator_[deviceId] = std::make_unique<hcl_communicator>(deviceId, pgComm_, config_json_path);
+  }
+  return *(hcl_communicator_.find(deviceId)->second);
+}
+// TBD: Store not used for now and config done from file
+// Initial support added for multiple devices on a single node
+// So using rank as the device id.  This will be enhanced further.
+ProcessGroupHCL::ProcessGroupHCL(
+    const std::shared_ptr<Store>& store,
+    int rank,
+    int size,
+    const std::chrono::milliseconds& opTimeout)
+    : ProcessGroup(rank, size), stop_(false) {
+
+}
+
+ProcessGroupHCL::~ProcessGroupHCL() {
+  destroy();
+}
+
+void ProcessGroupHCL::destroy() {
+
+}
+
+void ProcessGroupHCL::abort() {
+  destroy();
+
+}
+
+
+ProcessGroupHCL::WorkHCL::WorkHCL(const std::vector<at::Device>& devices)
+    : devices_(devices), workStartTime_(std::chrono::steady_clock::now()) {
+
+ // cudaEvents_.resize(devices.size());
+ // ncclComms_.resize(devices.size());
+}
+ProcessGroupHCL::WorkHCL::~WorkHCL() {}
+
+
+ProcessGroupHCL::WorkHCL::WorkHCL(const std::vector<at::Device>& devices)
+    : devices_(devices), workStartTime_(std::chrono::steady_clock::now()) {
+
+ // cudaEvents_.resize(devices.size());
+ // ncclComms_.resize(devices.size());
+}
+ProcessGroupHCL::WorkHCL::~WorkHCL() {}
+
+
+bool ProcessGroupHCL::WorkHCL::isCompleted() {
+
+  return exception() || true; //check for the completion of work;
+}
+
+bool ProcessGroupHCL::WorkHCL::isSuccess() const {
+  if (exception()) {
+    // Already detected an exception.
+    return false;
+  }
+
+  return true;
+}
+
+// Same as calling synchronize().
+bool ProcessGroupHCL::WorkHCL::wait() {
+  synchronize();
+  // Always return true, because abort API is not implemented.
+  return true;
+}
+
+void ProcessGroupHCL::WorkHCL::synchronize() {
+
+}
+
+void ProcessGroupHCL::WorkHCL::abort() {
+  TORCH_CHECK(false, "ProcessGroupHCL::WorkHCL::abort not implemented.");
+}
+
+
+  td::vector<at::Device> devices) {
+  return std::make_shared<ProcessGroupHCL::WorkHCL>(devices);
+}
+
+
+// Get the list of devices from list of tensors
+std::vector<at::Device> getDeviceList(const std::vector<at::Tensor>& tensors) {
+  std::vector<at::Device> res;
+  res.reserve(tensors.size());
+  for (auto& tensor : tensors) {
+    res.push_back(tensor.device());
+  }
+  return res;
+}
+
+
+template <typename Fn, typename PreProcess, typename PostProcess>
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::hclcollective(
+    std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs,
+    Fn fn,
+    PreProcess pre,
+    PostProcess post){
+
+  const auto devices = getDeviceList(inputs);
+  auto work = initWork(devices);
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    auto& hcl_comm = getComm(inputs[i].get_device());
+    fn(inputs[i], outputs[i], hcl_comm);
+  }
+
+  for (size_t i = 0; i < inputs.size(); ++i) {
+        // Update work
+  }
+  return work;
+}
+
+
+template <typename Fn>
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::hclcollective(
+    std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& outputs,
+    Fn fn) {
+
+    //Need to replace int by device work streams
+  return hclcollective(
+      inputs,
+      outputs,
+      fn,
+      [](std::vector<int>&) {},
+      [](std::vector<int>&) {});
+
+}
+
+
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::broadcast(
+    std::vector<at::Tensor>& tensors,
+    const BroadcastOptions& opts) {
+
+  //std::cout << "Broadcast called for rank " << getRank() << std::endl;
+  return hclcollective(
+    tensors,
+    tensors,
+    [&](at::Tensor& input,
+    at::Tensor& output,
+    hcl_communicator& hcl_comm) {
+                                    return hcl_comm.broadcast(opts.rootRank,
+                                    (synapse_helpers::device_ptr)input.data_ptr(),
+                                    input.numel(),
+                                    getHCLDataType(input.scalar_type()));
+                                });
+
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::allreduce(
+    std::vector<at::Tensor>& tensors,
+    const AllreduceOptions& opts) {
+
+  //std::cout << "Allreduce called for rank " << getRank() << std::endl;
+  return hclcollective(
+ ensors,
+    [&](at::Tensor& input,
+    at::Tensor& output,
+    hcl_communicator& hcl_comm) {
+                                    return hcl_comm.allreduce((synapse_helpers::device_ptr)input.data_ptr(),
+                                    (synapse_helpers::device_ptr)input.data_ptr(),
+                                    input.numel(),
+                                    getHCLDataType(input.scalar_type()));
+                                });
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::allreduce_coalesced(
+    std::vector<at::Tensor>& tensors,
+    const AllreduceCoalescedOptions& opts) {
+  throw std::runtime_error(
+      "allreduce_coalesced is currently not supported with HCL");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::reduce(
+    std::vector<at::Tensor>& tensors,
+    const ReduceOptions& opts) {
+
+  return hclcollective(
+    tensors,
+    tensors,
+    [&](at::Tensor& input,
+    at::Tensor& output,
+    hcl_communicator& hcl_comm) {
+                                    return hcl_comm.reduce(opts.rootRank,
+                                    (synapse_helpers::device_ptr)input.data_ptr(),
+                                    (synapse_helpers::device_ptr)output.data_ptr(),
+                                    input.numel(),
+                                    getHCLDataType(input.scalar_type()),
+                                    getHCLOpType(opts.reduceOp));
+                                });
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::allgather(
+    std::vector<std::vector<at::Tensor>>& outputTensors,
+    std::vector<at::Tensor>& inputTensors,
+    const AllgatherOptions& opts) {
+  throw std::runtime_error(
+      "allgather is currently not supported with HCL");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::allgather_base(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const AllgatherOptions& opts) {
+  throw std::runtime_error(
+      "allgather_base is currently not supported with HCL");
+}
+
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::allgather_coalesced(
+    std::vector<std::vector<at::Tensor>>& /* unused */,
+    std::vector<at::Tensor>& /* unused */,
+    const AllgatherOptions& /* unused */) {
+  throw std::runtime_error(
+      "ProcessGroupHCL does not support allgather_coalesced");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::gather(
+    std::vector<std::vector<at::Tensor>>& outputTensors,
+    std::vector<at::Tensor>& inputTensors,
+    const GatherOptions& opts) {
+  throw std::runtime_error(
+      "ProcessGroupHCL does not support gather");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::scatter(
+    std::vector<at::Tensor>& outputTensors,
+    std::vector<std::vector<at::Tensor>>& inputTensors,
+    const ScatterOptions& opts) {
+  throw std::runtime_error(
+      "ProcessGroupHCL does not support scatter");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::reduce_scatter(
+    std::vector<at::Tensor>& outputTensors,
+    std::vector<std::vector<at::Tensor>>& inputTensors,
+    const ReduceScatterOptions& opts) {
+  throw std::runtime_error("ProcessGroupHCL does not support reduce_scatter");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::send(
+    std::vector<at::Tensor>& tensors,
+    int dstRank,
+    int tag) {
+
+  return hclcollective(
+    tensors,
+    tensors,
+    [&](at::Tensor& input,
+    at::Tensor& output,
+    hcl_communicator& hcl_comm) {
+                                    return hcl_comm.send((synapse_helpers::device_ptr)input.data_ptr(),
+                                    input.numel() * sizeof(getHCLDataType(input.scalar_type())),
+                                    dstRank,
+                                    tag);
+                                });
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::recv(
+    std::vector<at::Tensor>& tensors,
+    int srcRank,
+    int tag) {
+
+  return hclcollective(
+    tensors,
+    tensors,
+    [&](at::Tensor& input,
+    at::Tensor& output,
+    hcl_communicator& hcl_comm) {
+                                    return hcl_comm.receive((synapse_helpers::device_ptr)input.data_ptr(),
+                                    input.numel() * sizeof(getHCLDataType(input.scalar_type())),
+                                    srcRank,
+                                    tag);
+                                });
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::recvAnysource(
+    std::vector<at::Tensor>& tensors,
+    int tag) {
+  throw std::runtime_error(
+      "ProcessGroupHCL does not support recv");
+}
+
+std::shared_ptr<ProcessGroup::Work> ProcessGroupHCL::barrier(
+    const BarrierOptions& opts) {
+
+  throw std::runtime_error(
+      "ProcessGroupHCL does not support barrier");
+}
+
+} // namespace c10d

--- a/torch/lib/c10d/ProcessGroupHCL.hpp
+++ b/torch/lib/c10d/ProcessGroupHCL.hpp
@@ -1,0 +1,144 @@
+#pragma once
+
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+
+#include <c10d/ProcessGroup.hpp>
+#include <c10d/Store.hpp>
+
+#include <hcl_communicator.h>
+
+namespace c10d {
+
+// Now continue on other work in the current stream.
+class ProcessGroupHCL : public ProcessGroup {
+ public:
+  class WorkHCL : public ProcessGroup::Work {
+   public:
+    // Constructor takes a list of CUDA devices
+    WorkHCL(const std::vector<at::Device>& devices);
+    virtual ~WorkHCL();
+
+    bool isCompleted() override;
+
+    bool isSuccess() const override;
+
+    bool wait() override;
+
+    void abort() override;
+
+    void synchronize() override;
+
+
+   protected:
+    std::vector<at::Device> devices_;
+    // Time point representing when the work started.
+    std::chrono::time_point<std::chrono::steady_clock> workStartTime_;
+   private:
+    friend class ProcessGroupHCL;
+  };
+
+  ProcessGroupHCL(
+      const std::shared_ptr<Store>& store,
+      int rank,
+      int size,
+      const std::chrono::milliseconds& opTimeout);
+
+  virtual ~ProcessGroupHCL();
+  void abort();
+
+  std::shared_ptr<ProcessGroup::Work> broadcast(
+      std::vector<at::Tensor>& data,
+      const BroadcastOptions& opts = BroadcastOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> allreduce(
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> allreduce_coalesced(
+      std::vector<at::Tensor>& tensors,
+      const AllreduceCoalescedOptions& opts =
+          AllreduceCoalescedOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> reduce(
+      std::vector<at::Tensor>& tensors,
+      const ReduceOptions& opts = ReduceOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> allgather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const AllgatherOptions& opts = AllgatherOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> allgather_base(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const AllgatherOptions& opts = AllgatherOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> allgather_coalesced(
+      std::vector<std::vector<at::Tensor>>& outputTensorLists,
+      std::vector<at::Tensor>& inputTensors,
+      const AllgatherOptions& opts = AllgatherOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> gather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const GatherOptions& opts = GatherOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> scatter(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ScatterOptions& opts = ScatterOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> reduce_scatter(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Work> send(
+      std::vector<at::Tensor>& tensors,
+      int dstRank,
+      int tag);
+
+  std::shared_ptr<ProcessGroup::Work> recv(
+      std::vector<at::Tensor>& tensors,
+      int srcRank,
+      int tag);
+
+  std::shared_ptr<ProcessGroup::Work> recvAnysource(
+      std::vector<at::Tensor>& tensor,
+      int tag);
+
+  std::shared_ptr<ProcessGroup::Work> barrier(
+
+ private:
+
+  // Helper that encapsulates work shared across all collective communication
+  template <typename Fn>
+  std::shared_ptr<ProcessGroup::Work> hclcollective(
+      std::vector<at::Tensor>& input,
+      std::vector<at::Tensor>& output,
+      Fn fn);
+  template <typename Fn, typename PreProcess, typename PostProcess>
+  std::shared_ptr<ProcessGroup::Work> hclcollective(
+      std::vector<at::Tensor>& input,
+      std::vector<at::Tensor>& output,
+      Fn fn,
+      PreProcess pre,
+      PostProcess post);
+
+ protected:
+
+  virtual std::shared_ptr<ProcessGroupHCL::WorkHCL> initWork(
+      std::vector<at::Device> devices);
+
+  synapse_helpers::hcl_communicator& getComm(int deviceId);
+  // Helper function that is called by the destructor
+  void destroy();
+  bool stop_;
+
+  //Maintains the list of communicators associated with the devices.
+  std::map<int, std::unique_ptr<synapse_helpers::hcl_communicator>> hcl_communicator_;
+};
+
+} // namespace c10d


### PR DESCRIPTION
The following changes are part of this patch -
  - Add Habana as a backend device type
  - Add HabanaTensorId as a DispatchKey for Habana backend
  - Adding support to recognize prim::HabanaFusedOp as an operator
  - Add allgather_base to ProcessGroupHCL
  - Update distributed test
  - Adding support to call autograd threshold for backward pass
    in lieu of symbolic implementation
  - After making the changes, verified by running test_jit.py
    test suite from tests dir
  - Add support for reduce collective
  - Temporary change to accomodate the lack of Integer allreduce
    support in HCL
  - Ensure convolution op in TorchScript is a differentiable op
    1. Added support in graph executor to ensure that TensorTypes
       are of the same device as IValue tensors
    2. Added support for checking if Tensor, types and other methods
       are on habana by defining helper functions
    3. Added checks in autodiff to ensure convolution is differentiable
       only for HPU
    4. Added symbolic script implementation for convolution and _convolution
  - Ensure BatchNorm is part of differentiable graph in TorchScript
    1. Enable BatchNorm implementation in symbolic script
    2. Added check to include batchnorm to be part of differentiable
       graph for HPU

